### PR TITLE
Handle correction failures and test decomposition matching

### DIFF
--- a/src/eigenpairflow/tracking.py
+++ b/src/eigenpairflow/tracking.py
@@ -111,6 +111,7 @@ def eigenpairtrack(
                 A_func, sol.t, Qs, Lambdas, method=correction_method
             )
         except Exception as e:
+            success = False
             message += f" | Correction failed with method '{correction_method}': {e}"
 
     # Calculate the final norm errors

--- a/src/eigenpairflow/visualization.py
+++ b/src/eigenpairflow/visualization.py
@@ -15,9 +15,9 @@ def plot_eigenvalue_trajectories(results: EigenTrackingResults, ax=None):
         show_plot = False
 
     if results.Lambdas is not None and results.t_eval is not None:
-        eigenvalues_traces = np.array([np.diag(L) for L in results.Lambdas])
-        for i in range(eigenvalues_traces.shape[1]):
-            ax.plot(results.t_eval, eigenvalues_traces[:, i], label=f"λ_{i+1}(t)")
+        eigenvalue_traces = np.array([np.diag(L) for L in results.Lambdas])
+        for i in range(eigenvalue_traces.shape[1]):
+            ax.plot(results.t_eval, eigenvalue_traces[:, i], label=f"λ_{i+1}(t)")
         ax.set_title("Eigenvalue Trajectories")
         ax.set_xlabel("Parameter t")
         ax.set_xscale("log")

--- a/test/test_match_decompositions.py
+++ b/test/test_match_decompositions.py
@@ -1,0 +1,19 @@
+import numpy as np
+from eigenpairflow.correction import match_decompositions
+
+
+def test_match_decompositions_reorders_and_aligns_signs():
+    # predicted decomposition with swapped order
+    predicted_eigvals = np.array([2.0, 1.0])
+    predicted_eigvecs = np.eye(2)
+
+    # exact decomposition in ascending order with a sign flip on the first vector
+    exact_eigvals = np.array([1.0, 2.0])
+    exact_eigvecs = np.array([[0.0, -1.0], [1.0, 0.0]])
+
+    matched_vals, matched_vecs = match_decompositions(
+        predicted_eigvals, predicted_eigvecs, exact_eigvals, exact_eigvecs
+    )
+
+    assert np.allclose(matched_vals, predicted_eigvals)
+    assert np.allclose(matched_vecs, predicted_eigvecs)


### PR DESCRIPTION
## Summary
- Rename `eigenvalues_traces` to clearer `eigenvalue_traces` in visualization
- Ensure tracking marks correction failures by setting `success=False`
- Add unit test verifying eigenvalue/vector matching handles ordering and sign

## Testing
- `pre-commit run --all-files` *(fails: RPC failed; HTTP 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd98307a1c8323b5721c7952f62f0d