### PR TITLE
Check t_eval start for Euler solver and add regression test

### DIFF
--- a/src/eigenpairflow/tracking.py
+++ b/src/eigenpairflow/tracking.py
@@ -49,6 +49,8 @@ def _track_symmetric_eigh(
 
     if solver_method.lower() == "euler":
         t_values = np.array(t_eval)
+        if not np.isclose(t_values[0], t0):
+            raise ValueError("t_eval must start with t_span[0] for Euler solver")
         num_steps = t_values.size
         y = np.zeros((y0.size, num_steps))
         y[:, 0] = y0

--- a/test/test_solver_methods.py
+++ b/test/test_solver_methods.py
@@ -43,3 +43,18 @@ def test_solver_method_combinations(solver_method, dense_output):
 
     assert results.success
     assert len(results.t_eval) == len(t_eval)
+
+
+def test_euler_requires_initial_time():
+    """Euler 法では ``t_eval`` の最初の値が開始時刻に一致しない場合に例外を送出することを確認する。"""
+    t_span = (0.0, 1.0)
+    t_eval = np.linspace(0.1, 1.0, 5)
+
+    with pytest.raises(ValueError):
+        eigenpairtrack(
+            _basic_matrix,
+            _d_basic_matrix,
+            t_span,
+            t_eval,
+            solver_method="Euler",
+        )


### PR DESCRIPTION
## Summary
- validate Euler ODE solver requires first t_eval to match t_span start
- add regression test for missing initial time in Euler solver

## Testing
- `poetry run pytest`
- `poetry run pre-commit run --all-files` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa0a45c548323abe99004c2723ee9